### PR TITLE
Added prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This script generates a background field image according to a csv formatted field design file and config.json.
 
+## Prerequisites
+
+- Python3
+- Packages
+  - `pillow`
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
It would be nice to have a note about the prerequisites to run the script. Actually, I got the following error for the first time running it and googled to find a way to obtain the `PIL` package.
```bash
% python3 csv2background.py -h                                                                                                                                                                                       [master]
Traceback (most recent call last):
  File "csv2background.py", line 7, in <module>
    from PIL import Image
ModuleNotFoundError: No module named 'PIL'
```